### PR TITLE
[1.16.4] Vanish Event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         maven { url = 'https://files.minecraftforge.net/maven' }
-        maven { url = 'https://dist.creeper.host/Sponge/maven' }
+        maven { url = 'https://repo.spongepowered.org/maven' }
         jcenter()
         mavenCentral()
     }

--- a/src/main/java/redstonedubstep/mods/vanishmod/PlayerVanishEvent.java
+++ b/src/main/java/redstonedubstep/mods/vanishmod/PlayerVanishEvent.java
@@ -1,0 +1,17 @@
+package redstonedubstep.mods.vanishmod;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+public class PlayerVanishEvent extends PlayerEvent {
+    private final boolean vanished;
+
+    public PlayerVanishEvent(PlayerEntity player, boolean vanished) {
+        super(player);
+        this.vanished = vanished;
+    }
+
+    public boolean isVanished() {
+        return vanished;
+    }
+}

--- a/src/main/java/redstonedubstep/mods/vanishmod/VanishUtil.java
+++ b/src/main/java/redstonedubstep/mods/vanishmod/VanishUtil.java
@@ -15,6 +15,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.server.ServerChunkProvider;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.MinecraftForge;
 
 public class VanishUtil {
 	public static List<ServerPlayerEntity> formatPlayerList(List<ServerPlayerEntity> rawList) {
@@ -58,6 +59,7 @@ public class VanishUtil {
 	public static void updateVanishedStatus(ServerPlayerEntity player, boolean vanished) {
 		player.getPersistentData().putBoolean("vanished", vanished);
 		player.setInvisible(vanished);
+		MinecraftForge.EVENT_BUS.post(new PlayerVanishEvent(player, vanished));
 	}
 
 	public static boolean isVanished(UUID uuid, ServerWorld world) {


### PR DESCRIPTION
While developing integration with this mod for a server side mod, an event was needed to efficiently update the player's state. The mixin maven also happened to break, so it was changed to the official sponge maven.

This PR adds:
- An event for when a player enters or exits vanish

This PR changes:
- The maven repo for mixin to Sponge instead of CreeperHost